### PR TITLE
Fix regression in container check logic (#8232)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3915,7 +3915,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
                     # We only try and narrow away 'None' for now
                     if not is_optional(item_type):
-                        pass
+                        continue
 
                     collection_item_type = get_proper_type(builtin_item_type(collection_type))
                     if collection_item_type is None or is_optional(collection_item_type):

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -550,6 +550,15 @@ else:
     reveal_type(b)  # N: Revealed type is 'Union[__main__.A, None]'
 [builtins fixtures/ops.pyi]
 
+[case testInferInWithErasedTypes]
+from typing import TypeVar, Callable
+
+T = TypeVar('T')
+def foo(f: Callable[[T], bool], it: T) -> None: ...
+
+foo(lambda x: x in [1, 2] and bool(), 3)
+[builtins fixtures/list.pyi]
+
 [case testWarnNoReturnWorksWithStrictOptional]
 # flags: --warn-no-return
 def f() -> None:


### PR DESCRIPTION
This PR fixes the crash reported in https://github.com/python/mypy/issues/8230,
by replacing the 'pass' with the 'continue', as suggested.

However, it does *not* fix the underlying root cause -- I don't think
I actually understand the relevant pieces of code enough to feel
confident volunteering a fix. So, I settled for just fixing the
regression.

Basically, it seems this bug is due to how we try inferring the type
of the lambda in multiple passes to resolve the types. We pencil in an
ErasedType during the first pass -- and then subsequently crash when
attempting to type check the body during that pass. I'll leave more
details about this in the linked issue.