### PR TITLE
Typeddict context returned correctly when unambiguous (#8212)

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1128,6 +1128,14 @@ class MessageBuilder:
         else:
             self.fail("TypedDict {} has no key '{}'".format(format_type(typ), item_name), context)
 
+    def typeddict_context_ambiguous(
+            self,
+            types: List[TypedDictType],
+            context: Context) -> None:
+        formatted_types = ', '.join(list(format_type_distinctly(*types)))
+        self.fail('Type of TypedDict is ambiguous, could be any of ({})'.format(
+                  formatted_types), context)
+
     def typeddict_key_cannot_be_deleted(
             self,
             typ: TypedDictType,

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -822,6 +822,27 @@ reveal_type(u(c, m_i_i)) # N: Revealed type is 'Union[typing.Mapping*[builtins.i
 reveal_type(u(c, m_s_a)) # N: Revealed type is 'Union[typing.Mapping*[builtins.str, Any], TypedDict('__main__.C', {'a': builtins.int, 'b': builtins.int})]'
 [builtins fixtures/dict.pyi]
 
+[case testTypedDictUnionUnambiguousCase]
+from typing import Union, Mapping, Any, cast
+from typing_extensions import TypedDict, Literal
+
+A = TypedDict('A', {'@type': Literal['a-type'], 'a': str})
+B = TypedDict('B', {'@type': Literal['b-type'], 'b': int})
+
+c: Union[A, B] = {'@type': 'a-type', 'a': 'Test'}
+reveal_type(c) # N: Revealed type is 'Union[TypedDict('__main__.A', {'@type': Literal['a-type'], 'a': builtins.str}), TypedDict('__main__.B', {'@type': Literal['b-type'], 'b': builtins.int})]'
+[builtins fixtures/tuple.pyi]
+
+[case testTypedDictUnionAmbiguousCase]
+from typing import Union, Mapping, Any, cast
+from typing_extensions import TypedDict, Literal
+
+A = TypedDict('A', {'@type': Literal['a-type'], 'a': str})
+B = TypedDict('B', {'@type': Literal['a-type'], 'a': str})
+
+c: Union[A, B] = {'@type': 'a-type', 'a': 'Test'} # E: Type of TypedDict is ambiguous, could be any of ("A", "B") \
+                                                  # E: Incompatible types in assignment (expression has type "Dict[str, str]", variable has type "Union[A, B]")
+[builtins fixtures/dict.pyi]
 
 -- Use dict literals
 


### PR DESCRIPTION
Fixes #8156

This is a suggestion as to how we could handle getting the Typeddict context from a 
Union with more than one Typeddict.

The idea is that we check each of the Typeddict types to find one who's keys match 
that of the expression, if more than one match it's then ambiguous. The slightly weird 
thing is that this matching is only applied in the Union case, if there is only a single 
Typeddict it's returned as before.

Co-authored-by: rhys-carbon <47317532+rhys-carbon@users.noreply.github.com>