### PR TITLE
Update common issues to include __init__ without arguments (#8303)

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -72,6 +72,32 @@ flagged as an error.
   e.g. the :py:func:`pow` builtin returns ``Any`` (see `typeshed issue 285
   <https://github.com/python/typeshed/issues/285>`_ for the reason).
 
+- **:py:meth:`__init__ <object.__init__>` method has no annotated 
+  arguments or return type annotation.** :py:meth:`__init__ <object.__init__>`
+  is considered fully-annotated **if at least one argument is annotated**, 
+  while mypy will infer the return type as ``None``.
+  The implication is that, for a :py:meth:`__init__ <object.__init__>` method
+  that has no argument, you'll have to explicitly annotate the return type 
+  as ``None`` to type-check this :py:meth:`__init__ <object.__init__>` method:
+
+  .. code-block:: python
+
+      def foo(s: str) -> str:
+          return s
+
+      class A():
+          def __init__(self, value: str): # Return type inferred as None, considered as typed method
+              self.value = value
+              foo(1) # error: Argument 1 to "foo" has incompatible type "int"; expected "str"
+
+      class B():
+          def __init__(self):  # No argument is annotated, considered as untyped method
+              foo(1)  # No error!
+      
+      class C():
+          def __init__(self) -> None:  # Must specify return type to type-check
+              foo(1) # error: Argument 1 to "foo" has incompatible type "int"; expected "str"
+
 - **Some imports may be silently ignored**.  Another source of
   unexpected ``Any`` values are the :option:`--ignore-missing-imports
   <mypy --ignore-missing-imports>` and :option:`--follow-imports=skip


### PR DESCRIPTION
This is the implication of #5677 where the return type of `__init__` is inferred given that at least one argument is typed.

However, if no argument is present in `__init__`, `-> None` becomes compulsory if we are to enable type-checking on that method without using `--check-untyped-defs` flag. I believe it is worth mentioning in the section of "No errors reported for obviously wrong code".