### PR TITLE
Fix mypyc failing to compile on CPython 3.10.0a6 (#10202)

### DIFF
--- a/mypyc/lib-rt/dict_ops.c
+++ b/mypyc/lib-rt/dict_ops.c
@@ -115,7 +115,7 @@ int CPyDict_UpdateFromAny(PyObject *dict, PyObject *stuff) {
     if (PyDict_CheckExact(dict)) {
         // Argh this sucks
         _Py_IDENTIFIER(keys);
-        if (PyDict_Check(stuff) || _PyObject_HasAttrId(stuff, &PyId_keys)) {
+        if (PyDict_Check(stuff) || _CPyObject_HasAttrId(stuff, &PyId_keys)) {
             return PyDict_Update(dict, stuff);
         } else {
             return PyDict_MergeFromSeq2(dict, stuff, 1);
@@ -135,7 +135,7 @@ PyObject *CPyDict_FromAny(PyObject *obj) {
             return NULL;
         }
         _Py_IDENTIFIER(keys);
-        if (_PyObject_HasAttrId(obj, &PyId_keys)) {
+        if (_CPyObject_HasAttrId(obj, &PyId_keys)) {
             res = PyDict_Update(dict, obj);
         } else {
             res = PyDict_MergeFromSeq2(dict, obj, 1);

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -389,4 +389,18 @@ _CPyDictView_New(PyObject *dict, PyTypeObject *type)
 }
 #endif
 
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >=10
+static int
+_CPyObject_HasAttrId(PyObject *v, _Py_Identifier *name) {
+    PyObject *tmp = NULL;
+    int result = _PyObject_LookupAttrId(v, name, &tmp);
+    if (tmp) {
+        Py_DECREF(tmp);
+    }
+    return result;
+}
+#else
+#define _CPyObject_HasAttrId _PyObject_HasAttrId
+#endif
+
 #endif

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -940,7 +940,10 @@ import sys
 
 # We lie about the version we are running in tests if it is 3.5, so
 # that hits a crash case.
-if sys.version_info[:2] == (3, 9):
+if sys.version_info[:2] == (3, 10):
+    def version() -> int:
+        return 10
+elif sys.version_info[:2] == (3, 9):
     def version() -> int:
         return 9
 elif sys.version_info[:2] == (3, 8):


### PR DESCRIPTION
* Fix mypyc failing to compile on CPython 3.10.0a6

_PyObject_HasAttrId() has been removed in
https://github.com/python/cpython/pull/22629

* Keep using _PyObject_HasAttrId when python version is too old

We could potentionally already use _PyObject_LookupAttrId starting with
python 3.7 instead of 3.10. I'm not sure if we should switch as soon or
as late as possible.

Alternatively we could also try backporting _PyObject_LookupAttrId to
<3.7.

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(Once you have, delete this section. If you leave it in, your PR may be closed without action.)

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

(Explain how this PR changes mypy.)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
