### PR TITLE
Use double quotes errors 'in async function, 'Cannot determine type o…

### DIFF
--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -450,7 +450,7 @@ In this example the definitions of ``x`` and ``y`` are circular:
 
    class Problem:
        def set_x(self) -> None:
-           # Error: Cannot determine type of 'y'  [has-type]
+           # Error: Cannot determine type of "y"  [has-type]
            self.x = self.y
 
        def set_y(self) -> None:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -219,7 +219,7 @@ def parse_type_comment(type_comment: str,
     except SyntaxError:
         if errors is not None:
             stripped_type = type_comment.split("#", 2)[0].strip()
-            err_msg = "{} '{}'".format(TYPE_COMMENT_SYNTAX_ERROR, stripped_type)
+            err_msg = '{} "{}"'.format(TYPE_COMMENT_SYNTAX_ERROR, stripped_type)
             errors.report(line, column, err_msg, blocker=True, code=codes.SYNTAX)
             return None, None
         else:
@@ -566,7 +566,7 @@ class ASTConverter:
                     arg_types.insert(0, AnyType(TypeOfAny.special_form))
             except SyntaxError:
                 stripped_type = n.type_comment.split("#", 2)[0].strip()
-                err_msg = "{} '{}'".format(TYPE_COMMENT_SYNTAX_ERROR, stripped_type)
+                err_msg = '{} "{}"'.format(TYPE_COMMENT_SYNTAX_ERROR, stripped_type)
                 self.fail(err_msg, lineno, n.col_offset)
                 if n.type_comment and n.type_comment[0] not in ["(", "#"]:
                     self.note('Suggestion: wrap argument types in parentheses',

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -405,7 +405,7 @@ class ASTConverter:
                     arg_types.insert(0, AnyType(TypeOfAny.special_form))
             except SyntaxError:
                 stripped_type = type_comment.split("#", 2)[0].strip()
-                err_msg = "{} '{}'".format(TYPE_COMMENT_SYNTAX_ERROR, stripped_type)
+                err_msg = '{} "{}"'.format(TYPE_COMMENT_SYNTAX_ERROR, stripped_type)
                 self.fail(err_msg, lineno, n.col_offset)
                 arg_types = [AnyType(TypeOfAny.from_error)] * len(args)
                 return_type = AnyType(TypeOfAny.from_error)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -909,10 +909,10 @@ class MessageBuilder:
                   code=codes.STRING_FORMATTING)
 
     def cannot_determine_type(self, name: str, context: Context) -> None:
-        self.fail("Cannot determine type of '%s'" % name, context, code=codes.HAS_TYPE)
+        self.fail('Cannot determine type of "%s"' % name, context, code=codes.HAS_TYPE)
 
     def cannot_determine_type_in_base(self, name: str, base: str, context: Context) -> None:
-        self.fail("Cannot determine type of '%s' in base class '%s'" % (name, base), context)
+        self.fail('Cannot determine type of "%s" in base class "%s"' % (name, base), context)
 
     def no_formal_self(self, name: str, item: CallableType, context: Context) -> None:
         self.fail('Attribute function "%s" with type %s does not accept self argument'

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3566,7 +3566,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             self.fail("'yield from' outside function", e, serious=True, blocker=True)
         else:
             if self.function_stack[-1].is_coroutine:
-                self.fail("'yield from' in async function", e, serious=True, blocker=True)
+                self.fail('"yield from" in async function', e, serious=True, blocker=True)
             else:
                 self.function_stack[-1].is_generator = True
         if e.expr:
@@ -3949,7 +3949,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         else:
             if self.function_stack[-1].is_coroutine:
                 if self.options.python_version < (3, 6):
-                    self.fail("'yield' in async function", expr, serious=True, blocker=True)
+                    self.fail('"yield" in async function', expr, serious=True, blocker=True)
                 else:
                     self.function_stack[-1].is_generator = True
                     self.function_stack[-1].is_async_generator = True

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -344,11 +344,11 @@ async def f() -> None:
 # flags: --python-version 3.5
 
 async def f():
-    yield None  # E: 'yield' in async function
+    yield None  # E: "yield" in async function
 async def g():
-    yield  # E: 'yield' in async function
+    yield  # E: "yield" in async function
 async def h():
-    x = yield  # E: 'yield' in async function
+    x = yield  # E: "yield" in async function
 [builtins fixtures/async_await.pyi]
 
 [case testNoYieldFromInAsyncDef]
@@ -359,8 +359,8 @@ async def g():
     x = yield from []
 [builtins fixtures/async_await.pyi]
 [out]
-main:3: error: 'yield from' in async function
-main:5: error: 'yield from' in async function
+main:3: error: "yield from" in async function
+main:5: error: "yield from" in async function
 
 [case testNoAsyncDefInPY2_python2]
 
@@ -554,7 +554,7 @@ async def f() -> AsyncGenerator[int, None]:
     pass
 
 async def gen() -> AsyncGenerator[int, None]:
-    yield from f()  # E: 'yield from' in async function
+    yield from f()  # E: "yield from" in async function
 
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-async.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -938,7 +938,7 @@ A.B = None # E: Cannot assign to a type
 [targets __main__]
 
 [case testAccessingClassAttributeWithTypeInferenceIssue]
-x = C.x # E: Cannot determine type of 'x'
+x = C.x # E: Cannot determine type of "x"
 def f() -> int: return 1
 class C:
     x = f()

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -235,7 +235,7 @@ y: Dict[int, int] = {
 [builtins fixtures/dict.pyi]
 
 [case testColumnCannotDetermineType]
-(x)  # E:2: Cannot determine type of 'x'
+(x)  # E:2: Cannot determine type of "x"
 x = None
 
 [case testColumnInvalidIndexing]
@@ -354,7 +354,7 @@ if int():
     # TODO: It would be better to point to the type comment
     xyz = 0  # type: blurbnard blarb
 [out]
-main:3:5: error: syntax error in type comment 'blurbnard blarb'
+main:3:5: error: syntax error in type comment "blurbnard blarb"
 
 [case testColumnProperty]
 class A:

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -38,7 +38,7 @@ def f(): # E: Type signature has too many arguments  [syntax]
     # type: (int) -> None
     1
 
-x = 0  # type: x y  # E: syntax error in type comment 'x y'  [syntax]
+x = 0  # type: x y  # E: syntax error in type comment "x y"  [syntax]
 
 [case testErrorCodeSyntaxError3]
 # This is a bit inconsistent -- syntax error would be more logical?
@@ -61,7 +61,7 @@ def f(): # E: Type signature has too many arguments  [syntax]
     # type: (int) -> None
     1
 
-x = 0  # type: x y  # E: syntax error in type comment 'x y'  [syntax]
+x = 0  # type: x y  # E: syntax error in type comment "x y"  [syntax]
 
 [case testErrorCodeSyntaxError3_python2]
 def f(): pass
@@ -460,7 +460,7 @@ c = {}  # E: Expected TypedDict key 'x' but found no keys  [typeddict-item]
 [builtins fixtures/dict.pyi]
 
 [case testErrorCodeCannotDetermineType]
-y = x  # E: Cannot determine type of 'x'  [has-type]
+y = x  # E: Cannot determine type of "x"  [has-type]
 reveal_type(y)  # N: Revealed type is "Any"
 x = None
 
@@ -700,8 +700,8 @@ main:2: error: Name "y" is not defined  [name-defined]
 x = y  # type: int  # type: ignored[foo]
 x = y  # type: int  # type: ignored [foo]
 [out]
-main:1: error: syntax error in type comment 'int'  [syntax]
-main:2: error: syntax error in type comment 'int'  [syntax]
+main:1: error: syntax error in type comment "int"  [syntax]
+main:2: error: syntax error in type comment "int"  [syntax]
 
 [case testErrorCode__exit__Return]
 class InvalidReturn:

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -4,7 +4,7 @@
 
 [case testFastParseTypeCommentSyntaxError]
 
-x = None # type: a : b  # E: syntax error in type comment 'a : b'
+x = None # type: a : b  # E: syntax error in type comment "a : b"
 
 [case testFastParseInvalidTypeComment]
 
@@ -14,13 +14,13 @@ x = None # type: a + b  # E: Invalid type comment or annotation
 -- This happens in both parsers.
 [case testFastParseFunctionAnnotationSyntaxError]
 
-def f():  # E: syntax error in type comment 'None -> None' # N: Suggestion: wrap argument types in parentheses
+def f():  # E: syntax error in type comment "None -> None" # N: Suggestion: wrap argument types in parentheses
   # type: None -> None
   pass
 
 [case testFastParseFunctionAnnotationSyntaxErrorSpaces]
 
-def f():  # E: syntax error in type comment 'None -> None' # N: Suggestion: wrap argument types in parentheses
+def f():  # E: syntax error in type comment "None -> None" # N: Suggestion: wrap argument types in parentheses
   # type:             None -> None
   pass
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5183,11 +5183,11 @@ class Sub(Base):
 
 [builtins fixtures/property.pyi]
 [out]
-tmp/a.py:3: error: Cannot determine type of 'foo'
-tmp/a.py:4: error: Cannot determine type of 'foo'
+tmp/a.py:3: error: Cannot determine type of "foo"
+tmp/a.py:4: error: Cannot determine type of "foo"
 [out2]
-tmp/a.py:3: error: Cannot determine type of 'foo'
-tmp/a.py:4: error: Cannot determine type of 'foo'
+tmp/a.py:3: error: Cannot determine type of "foo"
+tmp/a.py:4: error: Cannot determine type of "foo"
 
 [case testRedefinitionClass]
 import b

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1299,14 +1299,14 @@ class A: pass
 
 [case testAccessGlobalVarBeforeItsTypeIsAvailable]
 import typing
-x.y  # E: Cannot determine type of 'x'
+x.y  # E: Cannot determine type of "x"
 x = object()
 x.y  # E: "object" has no attribute "y"
 
 [case testAccessDataAttributeBeforeItsTypeIsAvailable]
 
 a = None # type: A
-a.x.y  # E: Cannot determine type of 'x'
+a.x.y  # E: Cannot determine type of "x"
 class A:
    def __init__(self) -> None:
        self.x = object()
@@ -1963,7 +1963,7 @@ class A:
 [out]
 
 [case testMultipassAndTopLevelVariable]
-y = x # E: Cannot determine type of 'x'
+y = x # E: Cannot determine type of "x"
 y()
 x = 1+0
 [out]
@@ -2066,7 +2066,7 @@ y = ''
 [case testMultipassAndCircularDependency]
 class A:
     def f(self) -> None:
-        self.x = self.y # E: Cannot determine type of 'y'
+        self.x = self.y # E: Cannot determine type of "y"
 
     def g(self) -> None:
         self.y = self.x
@@ -2146,7 +2146,7 @@ from typing import TypeVar, Callable
 T = TypeVar('T')
 def dec() -> Callable[[T], T]: pass
 
-A.g  # E: Cannot determine type of 'g'
+A.g  # E: Cannot determine type of "g"
 
 class A:
     @classmethod

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -19,7 +19,7 @@ reveal_type(g2)  # N: Revealed type is "def (x: Literal['A B'])"
 
 [case testLiteralInvalidTypeComment]
 from typing_extensions import Literal
-def f(x):  # E: syntax error in type comment '(A[) -> None'
+def f(x):  # E: syntax error in type comment "(A[) -> None"
     # type: (A[) -> None
     pass
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1398,7 +1398,7 @@ class C:
 import a
 b = 1 + 1
 [out]
-tmp/a.py:4: error: Cannot determine type of 'x2'
+tmp/a.py:4: error: Cannot determine type of "x2"
 
 [case testErrorInPassTwo1]
 import b

--- a/test-data/unit/check-multiple-inheritance.test
+++ b/test-data/unit/check-multiple-inheritance.test
@@ -238,8 +238,8 @@ class C:
 def dec(f: Callable[..., T]) -> Callable[..., T]:
     return f
 [out]
-main:3: error: Cannot determine type of 'f' in base class 'B'
-main:3: error: Cannot determine type of 'f' in base class 'C'
+main:3: error: Cannot determine type of "f" in base class "B"
+main:3: error: Cannot determine type of "f" in base class "C"
 
 [case testMultipleInheritance_NestedClassesWithSameName]
 class Mixin1:

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -738,7 +738,7 @@ class A:
 
     def f(self, x: Optional['A']) -> None:
         assert x
-        lambda: (self.y, x.a) # E: Cannot determine type of 'y'
+        lambda: (self.y, x.a) # E: Cannot determine type of "y"
         self.y = int()
 [builtins fixtures/isinstancelist.pyi]
 

--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -113,116 +113,116 @@ file:1: error: invalid syntax
 0
 x = 0 # type: A A
 [out]
-file:2: error: syntax error in type comment 'A A'
+file:2: error: syntax error in type comment "A A"
 
 [case testInvalidTypeComment2]
 0
 x = 0 # type: A[
 [out]
-file:2: error: syntax error in type comment 'A['
+file:2: error: syntax error in type comment "A["
 
 [case testInvalidTypeComment3]
 0
 x = 0 # type:
 [out]
-file:2: error: syntax error in type comment ''
+file:2: error: syntax error in type comment ""
 
 [case testInvalidTypeComment4]
 0
 x = 0 # type: *
 [out]
-file:2: error: syntax error in type comment '*'
+file:2: error: syntax error in type comment "*"
 
 [case testInvalidTypeComment5]
 0
 x = 0 # type:# some comment
 [out]
-file:2: error: syntax error in type comment ''
+file:2: error: syntax error in type comment ""
 
 [case testInvalidTypeComment6]
 0
 x = 0 # type: *# comment #6
 [out]
-file:2: error: syntax error in type comment '*'
+file:2: error: syntax error in type comment "*"
 
 [case testInvalidTypeComment7]
 0
 x = 0 # type: A B #comment #7
 [out]
-file:2: error: syntax error in type comment 'A B'
+file:2: error: syntax error in type comment "A B"
 
 [case testInvalidSignatureInComment1]
 def f(): # type: x
   pass
 [out]
-file:1: error: syntax error in type comment 'x'
+file:1: error: syntax error in type comment "x"
 file:1: note: Suggestion: wrap argument types in parentheses
 
 [case testInvalidSignatureInComment2]
 def f(): # type:
   pass
 [out]
-file:1: error: syntax error in type comment ''
+file:1: error: syntax error in type comment ""
 
 [case testInvalidSignatureInComment3]
 def f(): # type: (
   pass
 [out]
-file:1: error: syntax error in type comment '('
+file:1: error: syntax error in type comment "("
 
 [case testInvalidSignatureInComment4]
 def f(): # type: (.
   pass
 [out]
-file:1: error: syntax error in type comment '(.'
+file:1: error: syntax error in type comment "(."
 
 [case testInvalidSignatureInComment5]
 def f(): # type: (x
   pass
 [out]
-file:1: error: syntax error in type comment '(x'
+file:1: error: syntax error in type comment "(x"
 
 [case testInvalidSignatureInComment6]
 def f(): # type: (x)
   pass
 [out]
-file:1: error: syntax error in type comment '(x)'
+file:1: error: syntax error in type comment "(x)"
 
 [case testInvalidSignatureInComment7]
 def f(): # type: (x) -
   pass
 [out]
-file:1: error: syntax error in type comment '(x) -'
+file:1: error: syntax error in type comment "(x) -"
 
 [case testInvalidSignatureInComment8]
 def f(): # type: (x) ->
   pass
 [out]
-file:1: error: syntax error in type comment '(x) ->'
+file:1: error: syntax error in type comment "(x) ->"
 
 [case testInvalidSignatureInComment9]
 def f(): # type: (x) -> .
   pass
 [out]
-file:1: error: syntax error in type comment '(x) -> .'
+file:1: error: syntax error in type comment "(x) -> ."
 
 [case testInvalidSignatureInComment10]
 def f(): # type: (x) -> x x
   pass
 [out]
-file:1: error: syntax error in type comment '(x) -> x x'
+file:1: error: syntax error in type comment "(x) -> x x"
 
 [case testInvalidSignatureInComment11]
 def f(): # type: # abc comment
   pass
 [out]
-file:1: error: syntax error in type comment ''
+file:1: error: syntax error in type comment ""
 
 [case testInvalidSignatureInComment12]
 def f(): # type: (x) -> x x # comment #2
   pass
 [out]
-file:1: error: syntax error in type comment '(x) -> x x'
+file:1: error: syntax error in type comment "(x) -> x x"
 
 
 [case testDuplicateSignatures1]


### PR DESCRIPTION
…f' and 'syntax error in type comment' (#10282)

* in async function - double quotes

* Cannot determine type of - double quotes

* syntax error in type comment - double quotes

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(Once you have, delete this section. If you leave it in, your PR may be closed without action.)

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

(Explain how this PR changes mypy.)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
