### PR TITLE
[mypyc] Only lookup vtable indices if needed for method call emits (#…

### DIFF
--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -383,7 +383,6 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         rtype = op.receiver_type
         class_ir = rtype.class_ir
         name = op.method
-        method_idx = rtype.method_index(name)
         method = rtype.class_ir.get_method(name)
         assert method is not None
 
@@ -406,6 +405,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
                 dest, lib, NATIVE_PREFIX, method.cname(self.names), args))
         else:
             # Call using vtable.
+            method_idx = rtype.method_index(name)
             self.emit_line('{}CPY_GET_METHOD{}({}, {}, {}, {}, {})({}); /* {} */'.format(
                 dest, version, obj, self.emitter.type_struct_name(rtype.class_ir),
                 method_idx, rtype.struct_name(self.names), mtype, args, op.method))


### PR DESCRIPTION
…10290)

The vtable index is only needed for when we actually go through a
vtable lookup. I don't believe this is actually a major performance
improvement, but it should make it clearer what's important for each
branch.

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(Once you have, delete this section. If you leave it in, your PR may be closed without action.)

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

(Explain how this PR changes mypy.)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
