### PR TITLE
[mypyc] Improve support for compiling singledispatch (#10795)

### DIFF
--- a/mypyc/irbuild/context.py
+++ b/mypyc/irbuild/context.py
@@ -22,8 +22,7 @@ class FuncInfo:
                  is_nested: bool = False,
                  contains_nested: bool = False,
                  is_decorated: bool = False,
-                 in_non_ext: bool = False,
-                 is_singledispatch: bool = False) -> None:
+                 in_non_ext: bool = False) -> None:
         self.fitem = fitem
         self.name = name if not is_decorated else decorator_helper_name(name)
         self.class_name = class_name
@@ -48,7 +47,6 @@ class FuncInfo:
         self.contains_nested = contains_nested
         self.is_decorated = is_decorated
         self.in_non_ext = in_non_ext
-        self.is_singledispatch = is_singledispatch
 
         # TODO: add field for ret_type: RType = none_rprimitive
 

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -66,7 +66,7 @@ def build_ir(modules: List[MypyFile],
 
     for module in modules:
         # First pass to determine free symbols.
-        pbv = PreBuildVisitor()
+        pbv = PreBuildVisitor(errors, module)
         module.accept(pbv)
 
         # Construct and configure builder objects (cyclic runtime dependency).

--- a/mypyc/test-data/commandline.test
+++ b/mypyc/test-data/commandline.test
@@ -108,6 +108,7 @@ def f(x: int) -> int:
 from typing import List, Any, AsyncIterable
 from typing_extensions import Final
 from mypy_extensions import trait, mypyc_attr
+from functools import singledispatch
 
 def busted(b: bool) -> None:
     for i in range(1, 10, 0):  # E: range() step can't be zero
@@ -219,3 +220,23 @@ async def async_with() -> None:
 
 async def async_generators() -> AsyncIterable[int]:
     yield 1  # E: async generators are unimplemented
+
+@singledispatch
+def a(arg) -> None:
+    pass
+
+@decorator # E: Calling decorator after registering function not supported
+@a.register
+def g(arg: int) -> None:
+    pass
+
+@a.register
+@decorator
+def h(arg: str) -> None:
+    pass
+
+@decorator
+@decorator # E: Calling decorator after registering function not supported
+@a.register
+def i(arg: Foo) -> None:
+    pass

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -34,7 +34,7 @@ def test_specialize() -> None:
     assert fun(B())
     assert fun(A())
 
-[case testSuperclassImplementationNotUsedWhenSubclassHasImplementation-xfail]
+[case testSuperclassImplementationNotUsedWhenSubclassHasImplementation]
 from functools import singledispatch
 class A: pass
 class B(A): pass
@@ -122,21 +122,22 @@ def test_singledispatch() -> None:
     assert fun(0)
     assert not fun('a')
 
-[case testRegisterDoesntChangeFunction-xfail]
+[case testRegisterDoesntChangeFunction]
 from functools import singledispatch
 
 @singledispatch
 def fun(arg) -> bool:
     return False
 
-@fun.register
-def fun_specialized(arg: int) -> bool:
+@fun.register(int)
+def fun_specialized(arg) -> bool:
     return True
 
 def test_singledispatch() -> None:
     assert fun_specialized('a')
 
-[case testNoneIsntATypeWhenUsedAsArgumentToRegister-xfail]
+# TODO: turn this into a mypy error
+[case testNoneIsntATypeWhenUsedAsArgumentToRegister]
 from functools import singledispatch
 
 @singledispatch
@@ -144,8 +145,8 @@ def fun(arg) -> bool:
     return False
 
 try:
-    @fun.register(None)
-    def fun_specialized(arg) -> bool:
+    @fun.register
+    def fun_specialized(arg: None) -> bool:
         return True
 except TypeError:
     pass
@@ -167,7 +168,7 @@ def test_singledispatch() -> None:
     assert fun('a')
     assert not fun([1, 2])
 
-[case testTypeIsAnABC-xfail]
+[case testTypeIsAnABC]
 from functools import singledispatch
 from collections.abc import Mapping
 
@@ -182,25 +183,6 @@ def fun_specialized(arg: Mapping) -> bool:
 def test_singledispatch() -> None:
     assert not fun(1)
     assert fun({'a': 'b'})
-
-[case testArgumentDoesntMatchTypeOfAnySpecializedImplementationsOrDefaultImplementation-xfail]
-from functools import singledispatch
-class A: pass
-class B(A): pass
-
-@singledispatch
-def fun(arg: A) -> bool:
-    return False
-
-@fun.register
-def fun_specialized(arg: B) -> bool:
-    return True
-
-def test_singledispatch() -> None:
-    assert fun(B())
-    assert fun(A())
-    assert not fun([1, 2])
-
 
 [case testSingleDispatchMethod-xfail]
 from functools import singledispatchmethod
@@ -305,7 +287,7 @@ def test_sum_and_equal():
     tree3 = build(4)
     assert not equal(tree, tree3)
 
-[case testSimulateMypySingledispatch-xfail]
+[case testSimulateMypySingledispatch]
 from functools import singledispatch
 from mypy_extensions import trait
 from typing import Iterator, Union, TypeVar, Any, List, Type
@@ -321,10 +303,13 @@ class MypyFile(Node): pass
 class TypeInfo(Node): pass
 
 
+@trait
 class SymbolNode(Node): pass
+@trait
 class Expression(Node): pass
 class TypeVarLikeExpr(SymbolNode, Expression): pass
 class TypeVarExpr(TypeVarLikeExpr): pass
+class TypeAlias(SymbolNode): pass
 
 class Missing: pass
 MISSING = Missing()
@@ -364,12 +349,12 @@ def verify_list(stub, a, b) -> List[str]:
     return list(err.msg for err in verify(stub, a, b))
 
 def test_verify() -> None:
-    assert verify_list(Node(), 'a', ['a', 'b']) == ['unknown node type']
-    assert verify_list(MypyFile(), 'a', ['a', 'b']) == ['should be an int']
+    assert verify_list(TypeAlias(), 'a', ['a', 'b']) == ['unknown node type']
     assert verify_list(MypyFile(), MISSING, ['a', 'b']) == ["shouldn't be missing"]
     assert verify_list(MypyFile(), 5, ['a', 'b']) == ['in TypeInfo', 'hello']
     assert verify_list(TypeInfo(), str, ['a', 'b']) == ['in TypeInfo', 'hello']
-    assert verify_list(TypeVarExpr(), 'a', ['x', 'y']) == ['x', 'y']
+    assert verify_list(TypeVarExpr(), 'a', ['x', 'y']) == []
+
 
 [case testArgsInRegisteredImplNamedDifferentlyFromMainFunction]
 from functools import singledispatch
@@ -390,23 +375,23 @@ def test_singledispatch():
 from functools import singledispatch
 
 @singledispatch
-def f(arg, *, kwarg: bool = False) -> bool:
-    return not kwarg
+def f(arg, *, kwarg: int = 0) -> int:
+    return kwarg + 10
 
 @f.register
-def g(arg: int, *, kwarg: bool = True) -> bool:
-    return kwarg
+def g(arg: int, *, kwarg: int = 5) -> int:
+    return kwarg - 10
 
 def test_keywords():
-    assert f('a')
-    assert f('a', kwarg=False)
-    assert not f('a', kwarg=True)
+    assert f('a') == 10
+    assert f('a', kwarg=3) == 13
+    assert f('a', kwarg=7) == 17
 
-    assert f(1)
-    assert f(1, kwarg=True)
-    assert not f(1, kwarg=False)
+    assert f(1) == -5
+    assert f(1, kwarg=4) == -6
+    assert f(1, kwarg=6) == -4
 
-[case testGeneratorAndMultipleTypesOfIterable-xfail]
+[case testGeneratorAndMultipleTypesOfIterable]
 from functools import singledispatch
 from typing import *
 
@@ -422,3 +407,53 @@ def test_iterables():
     assert f(1) != [1]
     assert list(f(1)) == [1]
     assert f('a') == [0]
+
+[case testRegisterUsedAtSameTimeAsOtherDecorators]
+from functools import singledispatch
+from typing import TypeVar
+
+class A: pass
+class B: pass
+
+T = TypeVar('T')
+
+def decorator(f: T) -> T:
+    return f
+
+@singledispatch
+def f(arg) -> int:
+    return 0
+
+@f.register
+@decorator
+def h(arg: str) -> int:
+    return 2
+
+def test_singledispatch():
+    assert f(1) == 0
+    assert f('a') == 2
+
+[case testDecoratorModifiesFunction]
+from functools import singledispatch
+from typing import Callable, Any
+
+class A: pass
+
+def decorator(f: Callable[[Any], int]) -> Callable[[Any], int]:
+    def wrapper(x) -> int:
+        return f(x) * 7
+    return wrapper
+
+@singledispatch
+def f(arg) -> int:
+    return 10
+
+@f.register
+@decorator
+def h(arg: str) -> int:
+    return 5
+
+
+def test_singledispatch():
+    assert f('a') == 35
+    assert f(A()) == 10


### PR DESCRIPTION
This makes several improvements to the support for compiling singledispatch that was introduced in #10753 by:

* Making sure registered implementations defined later in a file take precedence when multiple overlap
 * Using non-native calls to registered implementations to allow for adding other decorators to registered functions (099b047)
 * Creating a separate function that dispatches to the correct implementation instead of adding code to dispatch to one of the registered implementations directly into the main singledispatch function, allowing the main singledispatch function to be a generator (59555e4)
 * Avoiding a compilation error when trying to dispatch on an ABC (2d40421)

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(Once you have, delete this section. If you leave it in, your PR may be closed without action.)

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

(Explain how this PR changes mypy.)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
