### PR TITLE
Fix ParamSpec semanal issue (#10866)

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3172,11 +3172,15 @@ class SemanticAnalyzer(NodeVisitor[None],
         # PEP 612 reserves the right to define bound, covariant and contravariant arguments to
         # ParamSpec in a later PEP. If and when that happens, we should do something
         # on the lines of process_typevar_parameters
-        paramspec_var = ParamSpecExpr(
-            name, self.qualified_name(name), self.object_type(), INVARIANT
-        )
-        paramspec_var.line = call.line
-        call.analyzed = paramspec_var
+
+        if not call.analyzed:
+            paramspec_var = ParamSpecExpr(
+                name, self.qualified_name(name), self.object_type(), INVARIANT
+            )
+            paramspec_var.line = call.line
+            call.analyzed = paramspec_var
+        else:
+            assert isinstance(call.analyzed, ParamSpecExpr)
         self.add_symbol(name, call.analyzed, s)
         return True
 


### PR DESCRIPTION
Recreating equivalent ParamSpecExpr objects causes the equality check in
is_same_symbol in add_symbol_table_node to fail, causing a name already
defined error.

Co-authored-by: hauntsaninja <>

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(Once you have, delete this section. If you leave it in, your PR may be closed without action.)

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

(Explain how this PR changes mypy.)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
