### PR TITLE
[mypyc] Use native calls in singledispatch dispatch functions (#10888)

### DIFF
--- a/mypyc/test-data/irbuild-singledispatch.test
+++ b/mypyc/test-data/irbuild-singledispatch.test
@@ -1,0 +1,47 @@
+[case testNativeCallsUsedInDispatchFunction]
+from functools import singledispatch
+@singledispatch
+def f(arg) -> bool:
+    return False
+
+@f.register
+def g(arg: int) -> bool:
+    return True
+[out]
+def __mypyc___mypyc_singledispatch_main_function_f___decorator_helper__(arg):
+    arg :: object
+L0:
+    return 0
+def __mypyc_f_decorator_helper__(arg):
+    arg, r0 :: object
+    r1 :: int32
+    r2 :: bit
+    r3 :: bool
+    r4 :: int
+    r5 :: bool
+    r6 :: dict
+    r7 :: str
+    r8, r9 :: object
+    r10 :: bool
+L0:
+    r0 = load_address PyLong_Type
+    r1 = PyObject_IsInstance(arg, r0)
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    if r3 goto L1 else goto L2 :: bool
+L1:
+    r4 = unbox(int, arg)
+    r5 = g(r4)
+    return r5
+L2:
+    r6 = __main__.globals :: static
+    r7 = '__mypyc___mypyc_singledispatch_main_function_f___decorator_helper__'
+    r8 = CPyDict_GetItem(r6, r7)
+    r9 = PyObject_CallFunctionObjArgs(r8, arg, 0)
+    r10 = unbox(bool, r9)
+    return r10
+def g(arg):
+    arg :: int
+L0:
+    return 1
+

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -34,6 +34,7 @@ files = [
     'irbuild-unreachable.test',
     'irbuild-isinstance.test',
     'irbuild-dunders.test',
+    'irbuild-singledispatch.test',
 ]
 
 


### PR DESCRIPTION
When generating calls to registered implementations in the dispatch
function for a singledispatch function, use a native call instead of a
non-native call to registered implementations to make dispatching
faster.

We still use non-native calls when the registered function has
non-register decorators, as using a native call in that case would cause
us to call the function without any modifications that the decorator
might do.

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(Once you have, delete this section. If you leave it in, your PR may be closed without action.)

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

(Explain how this PR changes mypy.)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
