### PR TITLE
[mypyc] Refactor: reuse format string parser (#10894)

### DIFF
--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -164,12 +164,12 @@ def f(s: str, num: int) -> None:
     s1 = "Hi! I'm {}, and I'm {} years old.".format(s, num)
     s2 = ''.format()
     s3 = 'abc'.format()
-    s3 = '}}{}{{{}}}{{{}'.format(num, num, num)
+    s4 = '}}{}{{{}}}{{{}'.format(num, num, num)
 [out]
 def f(s, num):
     s :: str
     num :: int
-    r0, r1, r2, r3, r4, s1, r5, s2, r6, s3, r7, r8, r9, r10, r11, r12, r13 :: str
+    r0, r1, r2, r3, r4, s1, r5, s2, r6, s3, r7, r8, r9, r10, r11, r12, r13, s4 :: str
 L0:
     r0 = CPyTagged_Str(num)
     r1 = "Hi! I'm "
@@ -188,7 +188,7 @@ L0:
     r11 = '{'
     r12 = '}{'
     r13 = CPyStr_Build(6, r10, r7, r11, r8, r12, r9)
-    s3 = r13
+    s4 = r13
     return 1
 
 [case testFStrings]


### PR DESCRIPTION
`parse_conversion_specifiers` and `parse_format_value` from mypy.checkstrformat 
can be reused when compiling string formatting. `can_optimize_format` and 
`split_braces` are useless now.

Adding `start_pos` as an attribute of ConversionSpecifier can not only help parse 
literals but also help generate useful error messages in the future.

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(Once you have, delete this section. If you leave it in, your PR may be closed without action.)

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

(Explain how this PR changes mypy.)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
