### PR TITLE
[mypyc] Use MRO of argument for dispatch in singledispatch functions …

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -260,11 +260,15 @@ class LowLevelIRBuilder:
             ret = self.shortcircuit_helper('or', bool_rprimitive, lambda: ret, other, line)
         return ret
 
-    def type_is_op(self, obj: Value, type_obj: Value, line: int) -> Value:
+    def get_type_of_obj(self, obj: Value, line: int) -> Value:
         ob_type_address = self.add(GetElementPtr(obj, PyObject, 'ob_type', line))
         ob_type = self.add(LoadMem(object_rprimitive, ob_type_address))
         self.add(KeepAlive([obj]))
-        return self.add(ComparisonOp(ob_type, type_obj, ComparisonOp.EQ, line))
+        return ob_type
+
+    def type_is_op(self, obj: Value, type_obj: Value, line: int) -> Value:
+        typ = self.get_type_of_obj(obj, line)
+        return self.add(ComparisonOp(typ, type_obj, ComparisonOp.EQ, line))
 
     def isinstance_native(self, obj: Value, class_ir: ClassIR, line: int) -> Value:
         """Fast isinstance() check for a native class.

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -123,6 +123,7 @@ def transform_mypy_file(builder: IRBuilder, mypyfile: MypyFile) -> None:
     # Generate ops.
     for node in mypyfile.defs:
         builder.accept(node)
+
     builder.maybe_add_implicit_return()
 
     # Generate special function representing module top level.

--- a/mypyc/test-data/irbuild-singledispatch.test
+++ b/mypyc/test-data/irbuild-singledispatch.test
@@ -8,38 +8,56 @@ def f(arg) -> bool:
 def g(arg: int) -> bool:
     return True
 [out]
-def __mypyc___mypyc_singledispatch_main_function_f___decorator_helper__(arg):
+def __mypyc_singledispatch_main_function_f__(arg):
     arg :: object
 L0:
     return 0
-def __mypyc_f_decorator_helper__(arg):
-    arg, r0 :: object
-    r1 :: int32
-    r2 :: bit
-    r3 :: bool
-    r4 :: int
-    r5 :: bool
-    r6 :: dict
-    r7 :: str
-    r8, r9 :: object
-    r10 :: bool
+def f(arg):
+    arg :: object
+    r0 :: dict
+    r1 :: object
+    r2 :: str
+    r3 :: object
+    r4 :: ptr
+    r5, r6, r7 :: object
+    r8 :: ptr
+    r9 :: object
+    r10 :: bit
+    r11 :: int
+    r12 :: bit
+    r13 :: int
+    r14 :: bool
+    r15 :: object
+    r16 :: bool
 L0:
-    r0 = load_address PyLong_Type
-    r1 = PyObject_IsInstance(arg, r0)
-    r2 = r1 >= 0 :: signed
-    r3 = truncate r1: int32 to builtins.bool
-    if r3 goto L1 else goto L2 :: bool
+    r0 = __main__.__mypyc_singledispatch_registry___main__.f__ :: static
+    r1 = functools :: module
+    r2 = '_find_impl'
+    r3 = CPyObject_GetAttr(r1, r2)
+    r4 = get_element_ptr arg ob_type :: PyObject
+    r5 = load_mem r4 :: builtins.object*
+    keep_alive arg
+    r6 = PyObject_CallFunctionObjArgs(r3, r5, r0, 0)
+    r7 = load_address PyLong_Type
+    r8 = get_element_ptr r6 ob_type :: PyObject
+    r9 = load_mem r8 :: builtins.object*
+    keep_alive r6
+    r10 = r9 == r7
+    if r10 goto L1 else goto L4 :: bool
 L1:
-    r4 = unbox(int, arg)
-    r5 = g(r4)
-    return r5
+    r11 = unbox(int, r6)
+    r12 = r11 == 0
+    if r12 goto L2 else goto L3 :: bool
 L2:
-    r6 = __main__.globals :: static
-    r7 = '__mypyc___mypyc_singledispatch_main_function_f___decorator_helper__'
-    r8 = CPyDict_GetItem(r6, r7)
-    r9 = PyObject_CallFunctionObjArgs(r8, arg, 0)
-    r10 = unbox(bool, r9)
-    return r10
+    r13 = unbox(int, arg)
+    r14 = g(r13)
+    return r14
+L3:
+    unreachable
+L4:
+    r15 = PyObject_CallFunctionObjArgs(r6, arg, 0)
+    r16 = unbox(bool, r15)
+    return r16
 def g(arg):
     arg :: int
 L0:

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -114,7 +114,7 @@ def test_singledispatch() -> None:
     assert fun(1)
     assert not fun('a')
 
-[case testUseRegisterAsAFunction]
+[case testUseRegisterAsAFunction-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -145,7 +145,7 @@ def test_singledispatch() -> None:
     assert fun_specialized('a')
 
 # TODO: turn this into a mypy error
-[case testNoneIsntATypeWhenUsedAsArgumentToRegister]
+[case testNoneIsntATypeWhenUsedAsArgumentToRegister-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -543,3 +543,61 @@ def f(arg) -> int:
 @f.register
 def g(arg: B) -> int:
     return 1
+
+[case testOrderCanOnlyBeDeterminedFromMRONotIsinstanceChecks]
+from mypy_extensions import trait
+from functools import singledispatch
+
+@trait
+class A: pass
+@trait
+class B: pass
+class AB(A, B): pass
+class BA(B, A): pass
+
+@singledispatch
+def f(arg) -> str:
+    return "default"
+    pass
+
+@f.register
+def fa(arg: A) -> str:
+    return "a"
+
+@f.register
+def fb(arg: B) -> str:
+    return "b"
+
+def test_singledispatch():
+    assert f(AB()) == "a"
+    assert f(BA()) == "b"
+
+[case testCallingFunctionBeforeAllImplementationsRegistered]
+from functools import singledispatch
+
+class A: pass
+class B(A): pass
+
+@singledispatch
+def f(arg) -> str:
+    return 'default'
+
+assert f(A()) == 'default'
+assert f(B()) == 'default'
+assert f(1) == 'default'
+
+@f.register
+def g(arg: A) -> str:
+    return 'a'
+
+assert f(A()) == 'a'
+assert f(B()) == 'a'
+assert f(1) == 'default'
+
+@f.register
+def _(arg: B) -> str:
+    return 'b'
+
+assert f(A()) == 'a'
+assert f(B()) == 'b'
+assert f(1) == 'default'


### PR DESCRIPTION
…(#10930)

This changes the implementation of singledispatch to look up the correct registered implementation to use at runtime using the MRO of the passed argument, instead of using a chain of isinstance checks for each registered implementation, for the reasons mentioned in mypyc/mypyc#802 (comment).

This doesn't support dynamically registering implementations yet, so 2 of the existing singledispatch tests that rely on that are marked as xfails for now.

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(Once you have, delete this section. If you leave it in, your PR may be closed without action.)

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

(Explain how this PR changes mypy.)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
