### PR TITLE
[mypyc] Use a cache to speed up singledispatch calls (#10972)

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -203,7 +203,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     fields['tp_name'] = '"{}"'.format(name)
 
     generate_full = not cl.is_trait and not cl.builtin_base
-    needs_getseters = not cl.is_generated
+    needs_getseters = cl.needs_getseters or not cl.is_generated
 
     if not cl.builtin_base:
         fields['tp_new'] = new_name

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -102,6 +102,9 @@ class ClassIR:
         self.has_dict = False
         # Do we allow interpreted subclasses? Derived from a mypyc_attr.
         self.allow_interpreted_subclasses = False
+        # Does this class need getseters to be generated for its attributes? (getseters are also
+        # added if is_generated is False)
+        self.needs_getseters = False
         # If this a subclass of some built-in python class, the name
         # of the object for that class. We currently only support this
         # in a few ad-hoc cases.
@@ -279,6 +282,7 @@ class ClassIR:
             'inherits_python': self.inherits_python,
             'has_dict': self.has_dict,
             'allow_interpreted_subclasses': self.allow_interpreted_subclasses,
+            'needs_getseters': self.needs_getseters,
             'builtin_base': self.builtin_base,
             'ctor': self.ctor.serialize(),
             # We serialize dicts as lists to ensure order is preserved
@@ -329,6 +333,7 @@ class ClassIR:
         ir.inherits_python = data['inherits_python']
         ir.has_dict = data['has_dict']
         ir.allow_interpreted_subclasses = data['allow_interpreted_subclasses']
+        ir.needs_getseters = data['needs_getseters']
         ir.builtin_base = data['builtin_base']
         ir.ctor = FuncDecl.deserialize(data['ctor'], ctx)
         ir.attributes = OrderedDict(

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -766,6 +766,11 @@ PyObject *CPySingledispatch_RegisterFunction(PyObject *singledispatch_func,
         goto fail;
     }
 
+    // clear the cache so we consider the newly added function when dispatching
+    PyObject *dispatch_cache = PyObject_GetAttrString(singledispatch_func, "dispatch_cache");
+    if (dispatch_cache == NULL) goto fail;
+    PyDict_Clear(dispatch_cache);
+
     Py_INCREF(func);
     return func;
 

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -119,7 +119,7 @@ method_op(
     error_kind=ERR_MAGIC)
 
 # dict.get(key)
-method_op(
+dict_get_method_with_none = method_op(
     name='get',
     arg_types=[dict_rprimitive, object_rprimitive],
     return_type=object_rprimitive,

--- a/mypyc/test-data/irbuild-singledispatch.test
+++ b/mypyc/test-data/irbuild-singledispatch.test
@@ -16,9 +16,17 @@ def f_obj.__init__(__mypyc_self__):
     __mypyc_self__ :: __main__.f_obj
     r0 :: dict
     r1 :: bool
+    r2 :: dict
+    r3 :: str
+    r4 :: int32
+    r5 :: bit
 L0:
     r0 = PyDict_New()
     __mypyc_self__.registry = r0; r1 = is_error
+    r2 = PyDict_New()
+    r3 = 'dispatch_cache'
+    r4 = PyObject_SetAttr(__mypyc_self__, r3, r2)
+    r5 = r4 >= 0 :: signed
     return 1
 def f_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
@@ -42,57 +50,70 @@ L0:
 def f_obj.__call__(__mypyc_self__, arg):
     __mypyc_self__ :: __main__.f_obj
     arg :: object
-    r0 :: dict
-    r1 :: str
-    r2 :: object
-    r3 :: str
-    r4, r5 :: object
-    r6 :: str
-    r7 :: object
-    r8 :: ptr
-    r9, r10, r11 :: object
-    r12 :: ptr
-    r13 :: object
-    r14 :: bit
-    r15 :: int
-    r16 :: bit
-    r17 :: int
-    r18 :: bool
-    r19 :: object
-    r20 :: bool
+    r0 :: ptr
+    r1 :: object
+    r2 :: dict
+    r3, r4 :: object
+    r5 :: bit
+    r6, r7 :: object
+    r8 :: str
+    r9 :: object
+    r10 :: dict
+    r11 :: object
+    r12 :: int32
+    r13 :: bit
+    r14 :: object
+    r15 :: ptr
+    r16 :: object
+    r17 :: bit
+    r18 :: int
+    r19 :: bit
+    r20 :: int
+    r21 :: bool
+    r22 :: object
+    r23 :: bool
 L0:
-    r0 = __main__.globals :: static
-    r1 = 'f'
-    r2 = CPyDict_GetItem(r0, r1)
-    r3 = 'registry'
-    r4 = CPyObject_GetAttr(r2, r3)
-    r5 = functools :: module
-    r6 = '_find_impl'
-    r7 = CPyObject_GetAttr(r5, r6)
-    r8 = get_element_ptr arg ob_type :: PyObject
-    r9 = load_mem r8 :: builtins.object*
+    r0 = get_element_ptr arg ob_type :: PyObject
+    r1 = load_mem r0 :: builtins.object*
     keep_alive arg
-    r10 = PyObject_CallFunctionObjArgs(r7, r9, r4, 0)
-    r11 = load_address PyLong_Type
-    r12 = get_element_ptr r10 ob_type :: PyObject
-    r13 = load_mem r12 :: builtins.object*
-    keep_alive r10
-    r14 = r13 == r11
-    if r14 goto L1 else goto L4 :: bool
+    r2 = __mypyc_self__.dispatch_cache
+    r3 = CPyDict_GetWithNone(r2, r1)
+    r4 = load_address _Py_NoneStruct
+    r5 = r3 != r4
+    if r5 goto L1 else goto L2 :: bool
 L1:
-    r15 = unbox(int, r10)
-    r16 = r15 == 0
-    if r16 goto L2 else goto L3 :: bool
+    r6 = r3
+    goto L3
 L2:
-    r17 = unbox(int, arg)
-    r18 = g(r17)
-    return r18
+    r7 = functools :: module
+    r8 = '_find_impl'
+    r9 = CPyObject_GetAttr(r7, r8)
+    r10 = __mypyc_self__.registry
+    r11 = PyObject_CallFunctionObjArgs(r9, r1, r10, 0)
+    r12 = CPyDict_SetItem(r2, r1, r11)
+    r13 = r12 >= 0 :: signed
+    r6 = r11
 L3:
-    unreachable
+    r14 = load_address PyLong_Type
+    r15 = get_element_ptr r6 ob_type :: PyObject
+    r16 = load_mem r15 :: builtins.object*
+    keep_alive r6
+    r17 = r16 == r14
+    if r17 goto L4 else goto L7 :: bool
 L4:
-    r19 = PyObject_CallFunctionObjArgs(r10, arg, 0)
-    r20 = unbox(bool, r19)
-    return r20
+    r18 = unbox(int, r6)
+    r19 = r18 == 0
+    if r19 goto L5 else goto L6 :: bool
+L5:
+    r20 = unbox(int, arg)
+    r21 = g(r20)
+    return r21
+L6:
+    unreachable
+L7:
+    r22 = PyObject_CallFunctionObjArgs(r6, arg, 0)
+    r23 = unbox(bool, r22)
+    return r23
 def g(arg):
     arg :: int
 L0:

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -655,3 +655,44 @@ with assertRaises(TypeError, 'Invalid first argument to `register()`'):
     @f.register
     def _():
         pass
+
+[file driver.py]
+import register
+
+[case testCacheClearedWhenNewFunctionRegistered]
+from functools import singledispatch
+
+@singledispatch
+def f(arg) -> str:
+    return 'default'
+
+[file register.py]
+from native import f
+class A: pass
+class B: pass
+class C: pass
+
+# annotated function
+assert f(A()) == 'default'
+@f.register
+def _(arg: A) -> str:
+    return 'a'
+assert f(A()) == 'a'
+
+# type passed as argument
+assert f(B()) == 'default'
+@f.register(B)
+def _(arg: B) -> str:
+    return 'b'
+assert f(B()) == 'b'
+
+# 2 argument form
+assert f(C()) == 'default'
+def c(arg) -> str:
+    return 'c'
+f.register(C, c)
+assert f(C()) == 'c'
+
+
+[file driver.py]
+import register


### PR DESCRIPTION
This adds a cache to the dispatching code for singledispatch functions,
which makes calling singledispatch functions much faster.

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(Once you have, delete this section. If you leave it in, your PR may be closed without action.)

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

(Explain how this PR changes mypy.)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
